### PR TITLE
feat: create a window using GLFW

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,4 +4,5 @@ BinPackArguments: false
 BinPackParameters: false
 ColumnLimit: 120
 IndentWidth: 4
+IncludeBlocks: Preserve
 Standard: c++20

--- a/src/engine/scene.cpp
+++ b/src/engine/scene.cpp
@@ -1,5 +1,5 @@
 #include "scene.h"
 
-#include <stdexcept>
-
-void gfx::Scene::Render() const { throw std::runtime_error{"Not implemented"}; }
+void gfx::Scene::Render() const {
+    /// not implemented
+}

--- a/src/game/CMakeLists.txt
+++ b/src/game/CMakeLists.txt
@@ -1,5 +1,7 @@
-add_executable(game main.cpp game.cpp)
+add_executable(game main.cpp game.cpp window.cpp)
+
+find_package(glfw3 CONFIG REQUIRED)
+target_link_libraries(game PRIVATE glfw)
 
 target_include_directories(game PRIVATE include)
-
 target_link_libraries(game PRIVATE engine math)

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -1,3 +1,16 @@
 #include "game.h"
 
-void gfx::Game::Run() const { engine_.Render(scene_); }
+gfx::Game::Game() : window_{"VkRender", 1600, 900} {
+    window_.OnKeyEvent([this](const auto key, const auto action) {
+        if (action == GLFW_PRESS && key == GLFW_KEY_ESCAPE) {
+            window_.Close();
+        }
+    });
+}
+
+void gfx::Game::Run() const {
+    while (!window_.Closed()) {
+        window_.Update();
+        engine_.Render(scene_);
+    }
+}

--- a/src/game/include/game.h
+++ b/src/game/include/game.h
@@ -2,14 +2,18 @@
 
 #include "engine.h"
 #include "scene.h"
+#include "window.h"
 
 namespace gfx {
 
 class Game {
 public:
+    Game();
+
     void Run() const;
 
 private:
+    Window window_;
     Engine engine_;
     Scene scene_;
 };

--- a/src/game/include/window.h
+++ b/src/game/include/window.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <concepts>
+#include <functional>
+#include <memory>
+
+#include <GLFW/glfw3.h>
+
+namespace gfx {
+
+class Window {
+public:
+    Window(const char* title, int width, int height);
+
+    void OnKeyEvent(std::invocable<int, int> auto&& fn) { on_key_event_ = std::forward<decltype(on_key_event_)>(fn); }
+
+    [[nodiscard]] bool Closed() const noexcept { return glfwWindowShouldClose(glfw_window_.get()) == GLFW_TRUE; }
+    void Close() const noexcept { glfwSetWindowShouldClose(glfw_window_.get(), GLFW_TRUE); }
+
+    void Update() const noexcept { glfwPollEvents(); }
+
+private:
+    std::unique_ptr<GLFWwindow, void (*)(GLFWwindow*)> glfw_window_{nullptr, nullptr};
+    std::function<void(int, int)> on_key_event_;
+};
+
+}  // namespace gfx

--- a/src/game/main.cpp
+++ b/src/game/main.cpp
@@ -2,13 +2,11 @@
 #include <iostream>
 
 #include "game.h"
-#include "vector3.h"
 
 int main() {
     try {
-        std::cout << gfx::Vector3{1.0, 2.0f, 3.0f} << std::endl;
-        constexpr gfx::Game kGame{};
-        kGame.Run();
+        const gfx::Game game;
+        game.Run();
     } catch (const std::exception& e) {
         std::cerr << e.what() << std::endl;
         return EXIT_FAILURE;

--- a/src/game/window.cpp
+++ b/src/game/window.cpp
@@ -1,0 +1,64 @@
+#include "window.h"
+
+#include <format>
+#include <iostream>
+#include <stdexcept>
+
+#include <GLFW/glfw3.h>
+
+namespace {
+
+class GlfwContext {
+public:
+    static const GlfwContext& Initialize() {
+        static const GlfwContext instance;
+        return instance;
+    }
+
+    GlfwContext(const GlfwContext&) = delete;
+    GlfwContext(GlfwContext&&) noexcept = delete;
+
+    GlfwContext& operator=(const GlfwContext&) = delete;
+    GlfwContext& operator=(GlfwContext&&) noexcept = delete;
+
+    ~GlfwContext() noexcept { glfwTerminate(); }
+
+private:
+    GlfwContext() {
+        glfwSetErrorCallback([](const int error_code, const char* description) {
+            std::cerr << std::format("GLFW error {}: {}\n", error_code, description);
+        });
+        if (glfwInit() == GLFW_FALSE) {
+            throw std::runtime_error{"GLFW initialization failed"};
+        }
+    }
+};
+
+const auto& glfw_context = GlfwContext::Initialize();
+
+using UniqueGlfwWindow = std::unique_ptr<GLFWwindow, void (*)(GLFWwindow*)>;
+
+UniqueGlfwWindow CreateGlfwWindow(const char* const title, const int width, const int height) {
+    glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
+    glfwWindowHint(GLFW_RESIZABLE, GLFW_FALSE);
+
+    auto* glfw_window = glfwCreateWindow(width, height, title, nullptr, nullptr);
+    if (glfw_window == nullptr) throw std::runtime_error{"GLFW window creation failed"};
+
+    return UniqueGlfwWindow{glfw_window, glfwDestroyWindow};
+}
+
+}  // namespace
+
+gfx::Window::Window(const char* const title, const int width, const int height)
+    : glfw_window_{CreateGlfwWindow(title, width, height)} {
+    glfwSetWindowUserPointer(glfw_window_.get(), this);
+
+    glfwSetKeyCallback(
+        glfw_window_.get(),
+        [](GLFWwindow* glfw_window, const int key, const int /*scancode*/, const int action, const int /*modifiers*/) {
+            if (const auto* self = static_cast<const Window*>(glfwGetWindowUserPointer(glfw_window))) {
+                self->on_key_event_(key, action);
+            }
+        });
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,5 +2,5 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "vkrender",
   "version": "0.1.0",
-  "dependencies": [ "catch2" ]
+  "dependencies": [ "catch2", "glfw3" ]
 }


### PR DESCRIPTION
The first step for any renderer is to display a window. Unfortunately, each operating system does this differently and there is no standard solution for achieving this.

To facilitate cross-platform window creation, a library called GLFW is added which handles the implementation details needed to display a window on Windows, Linux, and macOS. Additionally, GLFW also provides APIs for input handing for both keyboard/mouse and gamepad controllers. Although it was primarily developed for OpenGL, it does have explicit support for Vulkan.

Another library that was considered was SDL2 which has the added benefits of supporting more platforms such as iOS and Android in addition to audio support. However, the library contains many other superfluous features and is poorly documented compared to GLFW. In an effort to be lean, this project has opted to go with GLFW and can reconsider SDL when version 3 is released.

Window creation was confirmed to work on both Windows and Ubuntu using Windows Subsystem for Linux.

More information about GLFW can be found here: https://www.glfw.org.