### PR TITLE
feat: create a Vulkan instance

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,4 +2,3 @@ BasedOnStyle: Google
 AccessModifierOffset: -2
 ColumnLimit: 120
 IncludeBlocks: Preserve
-Standard: c++20

--- a/src/engine/CMakeLists.txt
+++ b/src/engine/CMakeLists.txt
@@ -1,6 +1,16 @@
-add_library(engine STATIC engine.cpp scene.cpp window.cpp)
+add_library(engine STATIC engine.cpp instance.cpp scene.cpp window.cpp)
 
 find_package(glfw3 CONFIG REQUIRED)
 target_link_libraries(engine PUBLIC glfw)
+
+find_package(Vulkan REQUIRED)
+target_link_libraries(engine PUBLIC Vulkan::Vulkan)
+
+find_package(VulkanHeaders CONFIG REQUIRED)
+target_link_libraries(engine PUBLIC Vulkan::Headers)
+
+target_compile_definitions(engine PUBLIC GLFW_INCLUDE_VULKAN
+                                  PUBLIC VULKAN_HPP_NO_CONSTRUCTORS
+                                  PUBLIC VULKAN_HPP_DISPATCH_LOADER_DYNAMIC=1)
 
 target_include_directories(engine PUBLIC include)

--- a/src/engine/include/engine.h
+++ b/src/engine/include/engine.h
@@ -1,11 +1,16 @@
 ﻿#pragma once
 
+#include "instance.h"
+
 namespace gfx {
 class Scene;
 
 class Engine {
 public:
   void Render(const Scene&) const;
+
+private:
+  Instance instance_;
 };
 
 }  // namespace gfx

--- a/src/engine/include/instance.h
+++ b/src/engine/include/instance.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <vulkan/vulkan.hpp>
+
+namespace gfx {
+
+class Instance {
+public:
+  Instance();
+
+  [[nodiscard]] const vk::Instance& operator*() const noexcept { return *instance_; }
+
+private:
+  vk::UniqueInstance instance_;
+};
+
+}  // namespace gfx

--- a/src/engine/include/window.h
+++ b/src/engine/include/window.h
@@ -14,7 +14,7 @@ public:
 
   void OnKeyEvent(std::invocable<int, int> auto&& fn) { on_key_event_ = std::forward<decltype(on_key_event_)>(fn); }
 
-  [[nodiscard]] bool Closed() const noexcept { return glfwWindowShouldClose(glfw_window_.get()) == GLFW_TRUE; }
+  [[nodiscard]] bool IsClosed() const noexcept { return glfwWindowShouldClose(glfw_window_.get()) == GLFW_TRUE; }
   void Close() const noexcept { glfwSetWindowShouldClose(glfw_window_.get(), GLFW_TRUE); }
 
   void Update() const noexcept { glfwPollEvents(); }

--- a/src/engine/instance.cpp
+++ b/src/engine/instance.cpp
@@ -1,0 +1,43 @@
+#include "instance.h"
+
+#include <cstdint>
+#include <stdexcept>
+#include <vector>
+
+#include <GLFW/glfw3.h>
+
+#if VULKAN_HPP_DISPATCH_LOADER_DYNAMIC == 1
+VULKAN_HPP_DEFAULT_DISPATCH_LOADER_DYNAMIC_STORAGE
+#endif
+
+gfx::Instance::Instance() {
+#if VULKAN_HPP_DISPATCH_LOADER_DYNAMIC == 1
+  static const vk::DynamicLoader loader;
+  const auto get_instance_proc_address = loader.getProcAddress<PFN_vkGetInstanceProcAddr>("vkGetInstanceProcAddr");
+  VULKAN_HPP_DEFAULT_DISPATCHER.init(get_instance_proc_address);
+#endif
+
+  constexpr vk::ApplicationInfo kApplicationInfo{.apiVersion = VK_API_VERSION_1_3};
+
+  std::vector<const char*> required_layer_names;
+#ifndef NDEBUG
+  required_layer_names.push_back("VK_LAYER_KHRONOS_validation");
+#endif
+
+  std::uint32_t required_extension_count{};
+  const auto** required_extension_names = glfwGetRequiredInstanceExtensions(&required_extension_count);
+  if (required_extension_names == nullptr) {
+    throw std::runtime_error{"No Vulkan instance extensions for window surface creation could be found"};
+  }
+
+  instance_ = vk::createInstanceUnique(
+      vk::InstanceCreateInfo{.pApplicationInfo = &kApplicationInfo,
+                             .enabledLayerCount = static_cast<std::uint32_t>(required_layer_names.size()),
+                             .ppEnabledLayerNames = required_layer_names.data(),
+                             .enabledExtensionCount = required_extension_count,
+                             .ppEnabledExtensionNames = required_extension_names});
+
+#if VULKAN_HPP_DISPATCH_LOADER_DYNAMIC == 1
+  VULKAN_HPP_DEFAULT_DISPATCHER.init(*instance_);
+#endif
+}

--- a/src/engine/window.cpp
+++ b/src/engine/window.cpp
@@ -31,6 +31,9 @@ private:
     if (glfwInit() == GLFW_FALSE) {
       throw std::runtime_error{"GLFW initialization failed"};
     }
+    if (glfwVulkanSupported() == GLFW_FALSE) {
+      throw std::runtime_error{"No Vulkan loader or installable client driver could be found"};
+    }
   }
 };
 

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -9,7 +9,7 @@ gfx::Game::Game() : window_{"VkRender", 1600, 900} {
 }
 
 void gfx::Game::Run() const {
-  while (!window_.Closed()) {
+  while (!window_.IsClosed()) {
     window_.Update();
     engine_.Render(scene_);
   }

--- a/src/game/main.cpp
+++ b/src/game/main.cpp
@@ -1,4 +1,5 @@
-﻿#include <exception>
+﻿#include <cstdlib>
+#include <exception>
 #include <iostream>
 
 #include "game.h"

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,5 +2,5 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "vkrender",
   "version": "0.1.0",
-  "dependencies": [ "catch2", "glfw3" ]
+  "dependencies": [ "catch2", "glfw3", "vulkan-hpp" ]
 }


### PR DESCRIPTION
There is no global state in Vulkan and all per-application state is stored in a VkInstance object. Creating a VkInstance object initializes the Vulkan library and allows the application to pass information about itself to the implementation.

Although trivial to create, initializing a Vulkan instance requires environment configuration to utilize Vulkan libraries. To achieve this, Vulkan-Hpp was added which, in addition to C++ bindings for the Vulkan C API, provides an implementation for a dynamic dispatch loader to load Vulkan APIs at runtime.

This commit also enables the LunarG validation layers for debug builds. As a result, the Vulkan SDK is currently required for debug builds (although it is not necessary for release builds because Vulkan-Hpp is managed by vcpkg). This requires a README update which is not included in this commit and is tracked by #21.

Relevant documentation:
- https://www.glfw.org/docs/3.3/vulkan_guide.html
- https://github.com/KhronosGroup/Vulkan-Hpp#extensions--per-device-function-pointers
- https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkCreateInstance.html

Closes #20.