### PR TITLE
feat: get Vulkan device queues

### DIFF
--- a/src/engine/include/device.h
+++ b/src/engine/include/device.h
@@ -2,6 +2,8 @@
 
 #include <vulkan/vulkan.hpp>
 
+#include "queue.h"
+
 namespace gfx {
 
 class Device {
@@ -9,8 +11,16 @@ public:
   Device(const vk::Instance& instance, const vk::SurfaceKHR& surface);
 
 private:
+  struct RankedPhysicalDevice;
+
+  explicit Device(RankedPhysicalDevice&& ranked_physical_device);
+
+  static RankedPhysicalDevice SelectPhysicalDevice(const vk::Instance&, const vk::SurfaceKHR&);
+  static RankedPhysicalDevice GetRankedPhysicalDevice(const vk::PhysicalDevice&, const vk::SurfaceKHR&);
+
   vk::PhysicalDevice physical_device_;
   vk::UniqueDevice device_;
+  Queue graphics_queue_, present_queue_;
 };
 
 }  // namespace gfx

--- a/src/engine/include/queue.h
+++ b/src/engine/include/queue.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <cstdint>
+
+#include <vulkan/vulkan.hpp>
+
+namespace gfx {
+
+class Queue {
+public:
+  Queue(const vk::Device& device, const std::uint32_t queue_family_index, const std::uint32_t queue_index) noexcept
+      : queue_{device.getQueue(queue_family_index, queue_index)}, queue_family_index_{queue_family_index} {}
+
+private:
+  vk::Queue queue_;
+  std::uint32_t queue_family_index_;
+};
+
+}  // namespace gfx

--- a/src/engine/instance.cpp
+++ b/src/engine/instance.cpp
@@ -1,25 +1,13 @@
 #include "instance.h"
 
-#include <array>
 #include <cstdint>
+#include <vector>
 
 #include "window.h"
 
 #if VULKAN_HPP_DISPATCH_LOADER_DYNAMIC == 1
 VULKAN_HPP_DEFAULT_DISPATCH_LOADER_DYNAMIC_STORAGE
 #endif
-
-namespace {
-
-constexpr auto GetInstanceLayers() {
-  return std::array{
-#ifndef NDEBUG
-      "VK_LAYER_KHRONOS_validation",
-#endif
-      "VK_LAYER_KHRONOS_synchronization2"};
-}
-
-}  // namespace
 
 gfx::Instance::Instance() {
 #if VULKAN_HPP_DISPATCH_LOADER_DYNAMIC == 1
@@ -29,15 +17,19 @@ gfx::Instance::Instance() {
 #endif
 
   static constexpr vk::ApplicationInfo kApplicationInfo{.apiVersion = VK_API_VERSION_1_3};
-  static constexpr auto kEnabledLayerNames = GetInstanceLayers();
-  const auto enabled_extension_names = Window::GetInstanceExtensions();
+  const std::vector<const char*> instance_layers{
+#ifndef NDEBUG
+      "VK_LAYER_KHRONOS_validation"
+#endif
+  };
+  const auto instance_extensions = Window::GetInstanceExtensions();
 
   instance_ = vk::createInstanceUnique(
       vk::InstanceCreateInfo{.pApplicationInfo = &kApplicationInfo,
-                             .enabledLayerCount = static_cast<std::uint32_t>(kEnabledLayerNames.size()),
-                             .ppEnabledLayerNames = kEnabledLayerNames.data(),
-                             .enabledExtensionCount = static_cast<std::uint32_t>(enabled_extension_names.size()),
-                             .ppEnabledExtensionNames = enabled_extension_names.data()});
+                             .enabledLayerCount = static_cast<std::uint32_t>(instance_layers.size()),
+                             .ppEnabledLayerNames = instance_layers.data(),
+                             .enabledExtensionCount = static_cast<std::uint32_t>(instance_extensions.size()),
+                             .ppEnabledExtensionNames = instance_extensions.data()});
 
 #if VULKAN_HPP_DISPATCH_LOADER_DYNAMIC == 1
   VULKAN_HPP_DEFAULT_DISPATCHER.init(*instance_);

--- a/src/engine/window.cpp
+++ b/src/engine/window.cpp
@@ -1,5 +1,6 @@
 #include "window.h"
 
+#include <cassert>
 #include <cstdint>
 #include <format>
 #include <iostream>

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -8,7 +8,7 @@ constexpr auto kWindowWidth = 900;
 }  // namespace
 
 gfx::Game::Game() noexcept : window_{"VkRender", kWindowHeight, kWindowWidth}, engine_{window_} {
-  window_.OnKeyEvent([this](const auto key, const auto action) noexcept {
+  window_.OnKeyEvent([this](const auto key, const auto action) {
     if (action == GLFW_PRESS && key == GLFW_KEY_ESCAPE) {
       window_.Close();
     }


### PR DESCRIPTION
Vulkan queues represent the primary abstraction for sending commands to the GPU.

During the physical device selection process, queue indices are identified and cached which are then used during the device creation process to specify which queue families should be used. After the logical device has been created, getting a Vulkan queue is a simple process involving one API call with the appropriate queue family and queue indices.

Despite the trivial nature of getting a Vulkan queue, the existing design made it difficult to achieve due to the requirement to cache queue family indices during the physical device selection process. This precludes initializing a gfx::Queue in the member initialization list without awkward use of forwarding arguments as a std::tuple. Although it's possible to achieve this in the constructor body, a default constructor for gfx::Queue was specifically avoided to enforce the class invariant of having member variables be fully initialized when later accessed with class APIs.

To mitigate this, a private constructor was added that uses the internal RankedPhysicalDevice which allows initializing everything in the member initialization list. This unfortunately requires exposing RankedPhysicalDevice as a nested subclass however this was mitigated by both forward declaring the type and making it private to gfx::Device. Note that this can be fixed when the project is transitioned to C++20 modules which has first class support for controlling which parts of the API are exported.

Relates to #25