### PR TITLE
feat: render a triangle

### DIFF
--- a/src/engine/device.cpp
+++ b/src/engine/device.cpp
@@ -58,10 +58,10 @@ gfx::RankedPhysicalDevice GetRankedPhysicalDevice(const vk::PhysicalDevice& phys
 
 gfx::RankedPhysicalDevice SelectPhysicalDevice(const vk::Instance& instance, const vk::SurfaceKHR& surface) {
   const auto ranked_physical_devices =
-      instance.enumeratePhysicalDevices() | std::ranges::views::transform([&surface](auto&& physical_device) {
+      instance.enumeratePhysicalDevices() | std::views::transform([&surface](auto&& physical_device) {
         return GetRankedPhysicalDevice(physical_device, surface);
       })
-      | std::ranges::views::filter([](auto&& ranked_physical_device) {
+      | std::views::filter([](auto&& ranked_physical_device) {
           return ranked_physical_device.rank != gfx::RankedPhysicalDevice::kInvalidRank;
         })
       | std::ranges::to<std::vector>();
@@ -73,14 +73,14 @@ gfx::RankedPhysicalDevice SelectPhysicalDevice(const vk::Instance& instance, con
 
 vk::UniqueDevice CreateDevice(const vk::PhysicalDevice& physical_device,
                               const QueueFamilyIndices& queue_family_indices) {
-  static constexpr float kHighestNormalizedQueuePriority = 1.0;
+  static constexpr auto kHighestNormalizedQueuePriority = 1.0f;
 
   const auto device_queue_create_info =
       std::unordered_set{queue_family_indices.graphics_index, queue_family_indices.present_index}
-      | std::ranges::views::transform([](const auto queue_family_index) {
+      | std::views::transform([](const auto queue_family_index) {
           assert(queue_family_index != QueueFamilyIndices::kInvalidIndex);
           return vk::DeviceQueueCreateInfo{.queueFamilyIndex = queue_family_index,
-                                           .queueCount = 1u,
+                                           .queueCount = 1,
                                            .pQueuePriorities = &kHighestNormalizedQueuePriority};
         })
       | std::ranges::to<std::vector>();
@@ -108,5 +108,5 @@ gfx::Device::Device(const vk::Instance& instance, const vk::SurfaceKHR& surface)
 gfx::Device::Device(RankedPhysicalDevice&& ranked_physical_device)
     : physical_device_{ranked_physical_device.physical_device},
       device_{CreateDevice(physical_device_, ranked_physical_device.queue_family_indices)},
-      graphics_queue_{*device_, ranked_physical_device.queue_family_indices.graphics_index, 0u},
-      present_queue_{*device_, ranked_physical_device.queue_family_indices.present_index, 0u} {}
+      graphics_queue_{*device_, ranked_physical_device.queue_family_indices.graphics_index, 0},
+      present_queue_{*device_, ranked_physical_device.queue_family_indices.present_index, 0} {}

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -1,10 +1,248 @@
 ﻿#include "engine/engine.h"
 
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <iostream>
+#include <ranges>
+#include <utility>
+
+#include "engine/shader_module.h"
 #include "engine/window.h"
+
+namespace {
+
+vk::UniqueRenderPass CreateRenderPass(const vk::Device& device, const gfx::Swapchain& swapchain) {
+  const vk::AttachmentDescription attachment_description{.format = swapchain.image_format(),
+                                                         .samples = vk::SampleCountFlagBits::e1,
+                                                         .loadOp = vk::AttachmentLoadOp::eClear,
+                                                         .storeOp = vk::AttachmentStoreOp::eStore,
+                                                         .stencilLoadOp = vk::AttachmentLoadOp::eDontCare,
+                                                         .stencilStoreOp = vk::AttachmentStoreOp::eDontCare,
+                                                         .initialLayout = vk::ImageLayout::eUndefined,
+                                                         .finalLayout = vk::ImageLayout::ePresentSrcKHR};
+
+  static constexpr vk::AttachmentReference kColorAttachmentReference{
+      .attachment = 0,
+      .layout = vk::ImageLayout::eColorAttachmentOptimal};
+
+  static constexpr vk::SubpassDescription kSubpassDescription{.pipelineBindPoint = vk::PipelineBindPoint::eGraphics,
+                                                              .colorAttachmentCount = 1,
+                                                              .pColorAttachments = &kColorAttachmentReference};
+
+  return device.createRenderPassUnique(vk::RenderPassCreateInfo{.attachmentCount = 1,
+                                                                .pAttachments = &attachment_description,
+                                                                .subpassCount = 1,
+                                                                .pSubpasses = &kSubpassDescription});
+}
+
+std::vector<vk::UniqueFramebuffer> CreateFramebuffers(const vk::Device& device,
+                                                      const gfx::Swapchain& swapchain,
+                                                      const vk::RenderPass& render_pass) {
+  return swapchain.image_views()
+         | std::views::transform([&device, &render_pass, &extent = swapchain.image_extent()](const auto& image_view) {
+             return device.createFramebufferUnique(vk::FramebufferCreateInfo{.renderPass = render_pass,
+                                                                             .attachmentCount = 1,
+                                                                             .pAttachments = &image_view,
+                                                                             .width = extent.width,
+                                                                             .height = extent.height,
+                                                                             .layers = 1});
+           })
+         | std::ranges::to<std::vector>();
+}
+
+vk::UniquePipeline CreateGraphicsPipeline(const vk::Device& device,
+                                          const gfx::Swapchain& swapchain,
+                                          const vk::PipelineLayout& pipeline_layout,
+                                          const vk::RenderPass& render_pass) {
+  const gfx::ShaderModule vertex_shader_module{device, vk::ShaderStageFlagBits::eVertex, "shaders/vertex.glsl"};
+  const gfx::ShaderModule fragment_shader_module{device, vk::ShaderStageFlagBits::eFragment, "shaders/fragment.glsl"};
+
+  const std::array shader_stage_create_info{
+      vk::PipelineShaderStageCreateInfo{.stage = vk::ShaderStageFlagBits::eVertex,
+                                        .module = *vertex_shader_module,
+                                        .pName = "main"},
+      vk::PipelineShaderStageCreateInfo{.stage = vk::ShaderStageFlagBits::eFragment,
+                                        .module = *fragment_shader_module,
+                                        .pName = "main"}};
+
+  static constexpr vk::PipelineVertexInputStateCreateInfo kVertexInputStateCreateInfo{
+      .vertexBindingDescriptionCount = 0,
+      .vertexAttributeDescriptionCount = 0};
+
+  static constexpr vk::PipelineInputAssemblyStateCreateInfo kInputAssemblyStateCreateInfo{
+      .topology = vk::PrimitiveTopology::eTriangleList};
+
+  const auto& swapchain_image_extent = swapchain.image_extent();
+  const vk::Viewport viewport{.x = 0.0f,
+                              .y = 0.0f,
+                              .width = static_cast<float>(swapchain_image_extent.width),
+                              .height = static_cast<float>(swapchain_image_extent.height),
+                              .minDepth = 0.0f,
+                              .maxDepth = 1.0f};
+  const vk::Rect2D scissor{.offset = vk::Offset2D{0, 0}, .extent = swapchain_image_extent};
+
+  const vk::PipelineViewportStateCreateInfo viewport_state_create_info{.viewportCount = 1,
+                                                                       .pViewports = &viewport,
+                                                                       .scissorCount = 1,
+                                                                       .pScissors = &scissor};
+
+  static constexpr vk::PipelineRasterizationStateCreateInfo kRasterizationStateCreateInfo{
+      .polygonMode = vk::PolygonMode::eFill,
+      .cullMode = vk::CullModeFlagBits::eBack,
+      .frontFace = vk::FrontFace::eCounterClockwise,
+      .lineWidth = 1.0f};
+
+  static constexpr vk::PipelineMultisampleStateCreateInfo kMultisampleStateCreateInfo{.rasterizationSamples =
+                                                                                          vk::SampleCountFlagBits::e1};
+
+  static constexpr vk::PipelineColorBlendAttachmentState kColorBlendAttachmentState{
+      .blendEnable = vk::True,
+      .srcColorBlendFactor = vk::BlendFactor::eSrcAlpha,
+      .dstColorBlendFactor = vk::BlendFactor::eOneMinusSrcAlpha,
+      .colorBlendOp = vk::BlendOp::eAdd,
+      .srcAlphaBlendFactor = vk::BlendFactor::eOne,
+      .dstAlphaBlendFactor = vk::BlendFactor::eZero,
+      .alphaBlendOp = vk::BlendOp::eAdd,
+      .colorWriteMask = vk::ColorComponentFlagBits::eR | vk::ColorComponentFlagBits::eG | vk::ColorComponentFlagBits::eB
+                        | vk::ColorComponentFlagBits::eA};
+
+  static constexpr vk::PipelineColorBlendStateCreateInfo kColorBlendStateCreateInfo{
+      .attachmentCount = 1,
+      .pAttachments = &kColorBlendAttachmentState,
+      .blendConstants = std::array{0.0f, 0.0f, 0.0f, 0.0f}};
+
+  auto [result, graphics_pipeline] = device.createGraphicsPipelineUnique(
+      nullptr,
+      vk::GraphicsPipelineCreateInfo{.stageCount = static_cast<std::uint32_t>(shader_stage_create_info.size()),
+                                     .pStages = shader_stage_create_info.data(),
+                                     .pVertexInputState = &kVertexInputStateCreateInfo,
+                                     .pInputAssemblyState = &kInputAssemblyStateCreateInfo,
+                                     .pViewportState = &viewport_state_create_info,
+                                     .pRasterizationState = &kRasterizationStateCreateInfo,
+                                     .pMultisampleState = &kMultisampleStateCreateInfo,
+                                     .pColorBlendState = &kColorBlendStateCreateInfo,
+                                     .layout = pipeline_layout,
+                                     .renderPass = render_pass,
+                                     .subpass = 0});
+  vk::resultCheck(result,
+                  std::format("Graphics pipeline creation failed with error {}", vk::to_string(result)).c_str());
+
+  return std::move(graphics_pipeline);  // return value optimization not available here
+}
+
+vk::UniqueCommandPool CreateCommandPool(const gfx::Device& device) {
+  return device->createCommandPoolUnique(
+      vk::CommandPoolCreateInfo{.flags = vk::CommandPoolCreateFlagBits::eResetCommandBuffer,
+                                .queueFamilyIndex = device.graphics_queue().queue_family_index()});
+}
+
+constexpr auto kMaxRenderFrames = 2;
+
+std::vector<vk::UniqueCommandBuffer> AllocateCommandBuffers(const vk::Device& device,
+                                                            const vk::CommandPool& command_pool) {
+  return device.allocateCommandBuffersUnique(vk::CommandBufferAllocateInfo{
+      .commandPool = command_pool,
+      .level = vk::CommandBufferLevel::ePrimary,
+      .commandBufferCount = kMaxRenderFrames,
+  });
+}
+
+std::vector<vk::UniqueSemaphore> CreateSemaphores(const vk::Device& device) {
+  std::vector<vk::UniqueSemaphore> semaphores;
+  semaphores.reserve(kMaxRenderFrames);
+
+  std::ranges::generate_n(std::back_inserter(semaphores), kMaxRenderFrames, [&device] {
+    return device.createSemaphoreUnique(vk::SemaphoreCreateInfo{});
+  });
+
+  return semaphores;
+}
+
+std::vector<vk::UniqueFence> CreateFences(const vk::Device& device) {
+  std::vector<vk::UniqueFence> fences;
+  fences.reserve(kMaxRenderFrames);
+
+  std::ranges::generate_n(std::back_inserter(fences), kMaxRenderFrames, [&device] {
+    return device.createFenceUnique(vk::FenceCreateInfo{.flags = vk::FenceCreateFlagBits::eSignaled});
+  });
+
+  return fences;
+}
+
+}  // namespace
 
 gfx::Engine::Engine(const Window& window)
     : surface_{window.CreateSurface(*instance_)},
       device_{*instance_, *surface_},
       swapchain_{device_, window, *surface_},
-      vertex_shader_module_{*device_, vk::ShaderStageFlagBits::eVertex, "shaders/vertex.glsl"},
-      fragment_shader_module_{*device_, vk::ShaderStageFlagBits::eFragment, "shaders/fragment.glsl"} {}
+      render_pass_{CreateRenderPass(*device_, swapchain_)},
+      framebuffers_{CreateFramebuffers(*device_, swapchain_, *render_pass_)},
+      graphics_pipeline_layout_{device_->createPipelineLayoutUnique(vk::PipelineLayoutCreateInfo{})},
+      graphics_pipeline_{CreateGraphicsPipeline(*device_, swapchain_, *graphics_pipeline_layout_, *render_pass_)},
+      command_pool_{CreateCommandPool(device_)},
+      command_buffers_{AllocateCommandBuffers(*device_, *command_pool_)},
+      acquire_next_image_semaphores_{CreateSemaphores(*device_)},
+      present_image_semaphores_{CreateSemaphores(*device_)},
+      draw_fences_{CreateFences(*device_)} {}
+
+gfx::Engine::~Engine() noexcept {
+  try {
+    device_->waitIdle();
+  } catch (const vk::SystemError& error) {
+    if (std::cerr.exceptions() == 0) {  // only report errors when std::cerr exceptions are disabled
+      std::cerr << error.what() << std::endl;
+    }
+  }
+}
+
+void gfx::Engine::Render() {
+  current_frame_index_ = (current_frame_index_ + 1) % kMaxRenderFrames;
+  const auto& command_buffer = *command_buffers_[current_frame_index_];
+  const auto& acquire_next_image_semaphore = *acquire_next_image_semaphores_[current_frame_index_];
+  const auto& present_image_semaphore = *present_image_semaphores_[current_frame_index_];
+  const auto& draw_fence = *draw_fences_[current_frame_index_];
+
+  static constexpr auto kMaxTimeout = std::numeric_limits<std::uint64_t>::max();
+  auto result = device_->waitForFences(draw_fence, vk::True, kMaxTimeout);
+  vk::resultCheck(result, std::format("vkWaitForFences failed with result {}", vk::to_string(result)).c_str());
+  device_->resetFences(draw_fence);
+
+  std::uint32_t image_index{};
+  std::tie(result, image_index) = device_->acquireNextImageKHR(*swapchain_, kMaxTimeout, acquire_next_image_semaphore);
+  vk::resultCheck(result, std::format("vkAcquireNextImageKHR failed with error {}", vk::to_string(result)).c_str());
+
+  command_buffer.begin(vk::CommandBufferBeginInfo{.flags = vk::CommandBufferUsageFlagBits::eOneTimeSubmit});
+
+  static constexpr vk::ClearValue kClearValue{.color = vk::ClearColorValue{std::array{0.0f, 0.0f, 0.0f, 1.0f}}};
+  command_buffer.beginRenderPass(vk::RenderPassBeginInfo{.renderPass = *render_pass_,
+                                                         .framebuffer = *framebuffers_[image_index],
+                                                         .renderArea = vk::Rect2D{.offset = vk::Offset2D{0, 0},
+                                                                                  .extent = swapchain_.image_extent()},
+                                                         .clearValueCount = 1,
+                                                         .pClearValues = &kClearValue},
+                                 vk::SubpassContents::eInline);
+
+  command_buffer.bindPipeline(vk::PipelineBindPoint::eGraphics, *graphics_pipeline_);
+  command_buffer.draw(3, 1, 0, 0);
+
+  command_buffer.endRenderPass();
+  command_buffer.end();
+
+  static constexpr vk::PipelineStageFlags kWaitPipelineStage = vk::PipelineStageFlagBits::eTopOfPipe;
+  device_.graphics_queue()->submit(vk::SubmitInfo{.waitSemaphoreCount = 1,
+                                                  .pWaitSemaphores = &acquire_next_image_semaphore,
+                                                  .pWaitDstStageMask = &kWaitPipelineStage,
+                                                  .commandBufferCount = 1,
+                                                  .pCommandBuffers = &command_buffer,
+                                                  .signalSemaphoreCount = 1,
+                                                  .pSignalSemaphores = &present_image_semaphore},
+                                   draw_fence);
+
+  result = device_.present_queue()->presentKHR(vk::PresentInfoKHR{.waitSemaphoreCount = 1,
+                                                                  .pWaitSemaphores = &present_image_semaphore,
+                                                                  .swapchainCount = 1,
+                                                                  .pSwapchains = &(*swapchain_),
+                                                                  .pImageIndices = &image_index});
+  vk::resultCheck(result, std::format("vkQueuePresentKHR failed with error {}", vk::to_string(result)).c_str());
+}

--- a/src/engine/glslang_compiler.cpp
+++ b/src/engine/glslang_compiler.cpp
@@ -27,12 +27,12 @@ constexpr auto kGlslangMessages =
 
 std::ostream& operator<<(std::ostream& ostream, glslang_shader_t* const shader) {
   if (const auto* const shader_info_log = glslang_shader_get_info_log(shader);
-      shader_info_log != nullptr && std::strlen(shader_info_log) > 0u) {
+      shader_info_log != nullptr && std::strlen(shader_info_log) > 0) {
     std::println(ostream, "{}", shader_info_log);
   }
 #ifndef NDEBUG
   if (const auto* const shader_info_debug_log = glslang_shader_get_info_debug_log(shader);
-      shader_info_debug_log != nullptr && std::strlen(shader_info_debug_log) > 0u) {
+      shader_info_debug_log != nullptr && std::strlen(shader_info_debug_log) > 0) {
     std::println(ostream, "{}", shader_info_debug_log);
   }
 #endif
@@ -41,12 +41,12 @@ std::ostream& operator<<(std::ostream& ostream, glslang_shader_t* const shader) 
 
 std::ostream& operator<<(std::ostream& ostream, glslang_program_t* const program) {
   if (const auto* const program_info_log = glslang_program_get_info_log(program);
-      program_info_log != nullptr && std::strlen(program_info_log) > 0u) {
+      program_info_log != nullptr && std::strlen(program_info_log) > 0) {
     std::println(ostream, "{}", program_info_log);
   }
 #ifndef NDEBUG
   if (const auto* const program_info_debug_log = glslang_program_get_info_debug_log(program);
-      program_info_debug_log != nullptr && std::strlen(program_info_debug_log) > 0u) {
+      program_info_debug_log != nullptr && std::strlen(program_info_debug_log) > 0) {
     std::println(ostream, "{}", program_info_debug_log);
   }
 #endif
@@ -141,22 +141,20 @@ struct std::formatter<glslang_stage_t> : std::formatter<std::string_view> {
 private:
   static constexpr std::string_view to_string(const glslang_stage_t stage) noexcept {
     switch (stage) {
-#define TO_STRING(kGlslangStage) #kGlslangStage  // NOLINT(cppcoreguidelines-macro-usage)
-      case GLSLANG_STAGE_VERTEX: return TO_STRING(GLSLANG_STAGE_VERTEX);
-      case GLSLANG_STAGE_TESSCONTROL: return TO_STRING(GLSLANG_STAGE_TESSCONTROL);
-      case GLSLANG_STAGE_TESSEVALUATION: return TO_STRING(GLSLANG_STAGE_TESSEVALUATION);
-      case GLSLANG_STAGE_GEOMETRY: return TO_STRING(GLSLANG_STAGE_GEOMETRY);
-      case GLSLANG_STAGE_FRAGMENT: return TO_STRING(GLSLANG_STAGE_FRAGMENT);
-      case GLSLANG_STAGE_COMPUTE: return TO_STRING(GLSLANG_STAGE_COMPUTE);
-      case GLSLANG_STAGE_RAYGEN: return TO_STRING(GLSLANG_STAGE_RAYGEN);
-      case GLSLANG_STAGE_INTERSECT: return TO_STRING(GLSLANG_STAGE_INTERSECT);
-      case GLSLANG_STAGE_ANYHIT: return TO_STRING(GLSLANG_STAGE_ANYHIT);
-      case GLSLANG_STAGE_CLOSESTHIT: return TO_STRING(GLSLANG_STAGE_CLOSESTHIT);
-      case GLSLANG_STAGE_MISS: return TO_STRING(GLSLANG_STAGE_MISS);
-      case GLSLANG_STAGE_CALLABLE: return TO_STRING(GLSLANG_STAGE_CALLABLE);
-      case GLSLANG_STAGE_TASK: return TO_STRING(GLSLANG_STAGE_TASK);
-      case GLSLANG_STAGE_MESH: return TO_STRING(GLSLANG_STAGE_MESH);
-#undef TO_STRING
+      case GLSLANG_STAGE_VERTEX: return "GLSLANG_STAGE_VERTEX";
+      case GLSLANG_STAGE_TESSCONTROL: return "GLSLANG_STAGE_TESSCONTROL";
+      case GLSLANG_STAGE_TESSEVALUATION: return "GLSLANG_STAGE_TESSEVALUATION";
+      case GLSLANG_STAGE_GEOMETRY: return "GLSLANG_STAGE_GEOMETRY";
+      case GLSLANG_STAGE_FRAGMENT: return "GLSLANG_STAGE_FRAGMENT";
+      case GLSLANG_STAGE_COMPUTE: return "GLSLANG_STAGE_COMPUTE";
+      case GLSLANG_STAGE_RAYGEN: return "GLSLANG_STAGE_RAYGEN";
+      case GLSLANG_STAGE_INTERSECT: return "GLSLANG_STAGE_INTERSECT";
+      case GLSLANG_STAGE_ANYHIT: return "GLSLANG_STAGE_ANYHIT";
+      case GLSLANG_STAGE_CLOSESTHIT: return "GLSLANG_STAGE_CLOSESTHIT";
+      case GLSLANG_STAGE_MISS: return "GLSLANG_STAGE_MISS";
+      case GLSLANG_STAGE_CALLABLE: return "GLSLANG_STAGE_CALLABLE";
+      case GLSLANG_STAGE_TASK: return "GLSLANG_STAGE_TASK";
+      case GLSLANG_STAGE_MESH: return "GLSLANG_STAGE_MESH";
       default: std::unreachable();
     }
   }

--- a/src/engine/include/engine/engine.h
+++ b/src/engine/include/engine/engine.h
@@ -1,11 +1,12 @@
 #ifndef SRC_ENGINE_INCLUDE_ENGINE_ENGINE_H_
 #define SRC_ENGINE_INCLUDE_ENGINE_ENGINE_H_
 
+#include <vector>
+
 #include <vulkan/vulkan.hpp>
 
 #include "engine/device.h"
 #include "engine/instance.h"
-#include "engine/shader_module.h"
 #include "engine/swapchain.h"
 
 namespace gfx {
@@ -15,12 +16,30 @@ class Engine {
 public:
   explicit Engine(const Window& window);
 
+  Engine(const Engine&) = delete;
+  Engine(Engine&&) noexcept = delete;
+
+  Engine& operator=(const Engine&) = delete;
+  Engine& operator=(Engine&&) noexcept = delete;
+
+  ~Engine() noexcept;
+
+  void Render();
+
 private:
   Instance instance_;
   vk::UniqueSurfaceKHR surface_;
   Device device_;
   Swapchain swapchain_;
-  ShaderModule vertex_shader_module_, fragment_shader_module_;
+  vk::UniqueRenderPass render_pass_;
+  std::vector<vk::UniqueFramebuffer> framebuffers_;
+  vk::UniquePipelineLayout graphics_pipeline_layout_;
+  vk::UniquePipeline graphics_pipeline_;
+  vk::UniqueCommandPool command_pool_;
+  std::vector<vk::UniqueCommandBuffer> command_buffers_;
+  std::vector<vk::UniqueSemaphore> acquire_next_image_semaphores_, present_image_semaphores_;
+  std::vector<vk::UniqueFence> draw_fences_;
+  std::uint32_t current_frame_index_ = 0;
 };
 
 }  // namespace gfx

--- a/src/engine/include/engine/queue.h
+++ b/src/engine/include/engine/queue.h
@@ -12,6 +12,9 @@ public:
   Queue(const vk::Device& device, const std::uint32_t queue_family_index, const std::uint32_t queue_index) noexcept
       : queue_{device.getQueue(queue_family_index, queue_index)}, queue_family_index_{queue_family_index} {}
 
+  [[nodiscard]] const vk::Queue& operator*() const noexcept { return queue_; }
+  [[nodiscard]] const vk::Queue* operator->() const noexcept { return &queue_; }
+
   [[nodiscard]] std::uint32_t queue_family_index() const noexcept { return queue_family_index_; }
 
 private:

--- a/src/engine/include/engine/shader_module.h
+++ b/src/engine/include/engine/shader_module.h
@@ -13,11 +13,8 @@ public:
 
   [[nodiscard]] const vk::ShaderModule& operator*() const noexcept { return *shader_module_; }
 
-  [[nodiscard]] vk::ShaderStageFlagBits stage() const noexcept { return shader_stage_; }
-
 private:
   vk::UniqueShaderModule shader_module_;
-  vk::ShaderStageFlagBits shader_stage_;
 };
 
 }  // namespace gfx

--- a/src/engine/include/engine/swapchain.h
+++ b/src/engine/include/engine/swapchain.h
@@ -1,6 +1,7 @@
 #ifndef SRC_ENGINE_INCLUDE_ENGINE_SWAPCHAIN_H_
 #define SRC_ENGINE_INCLUDE_ENGINE_SWAPCHAIN_H_
 
+#include <experimental/generator>
 #include <vector>
 
 #include <vulkan/vulkan.hpp>
@@ -10,8 +11,23 @@ class Device;
 class Window;
 
 class Swapchain {
+  template <typename T>
+  using generator = std::experimental::generator<T>;
+
 public:
   Swapchain(const Device& device, const Window& window, const vk::SurfaceKHR& surface);
+
+  [[nodiscard]] const vk::SwapchainKHR& operator*() const noexcept { return *swapchain_; }
+  [[nodiscard]] const vk::SwapchainKHR* operator->() const noexcept { return &(*swapchain_); }
+
+  [[nodiscard]] vk::Format image_format() const noexcept { return image_format_; }
+  [[nodiscard]] const vk::Extent2D& image_extent() const noexcept { return image_extent_; }
+
+  [[nodiscard]] generator<vk::ImageView> image_views() const {
+    for (const auto& image_view : image_views_) {
+      co_yield *image_view;
+    }
+  }
 
 private:
   vk::UniqueSwapchainKHR swapchain_;

--- a/src/engine/swapchain.cpp
+++ b/src/engine/swapchain.cpp
@@ -62,7 +62,7 @@ vk::Extent2D GetSwapchainImageExtent(const gfx::Window& window,
 std::vector<vk::UniqueImageView> CreateSwapchainImageViews(const vk::Device& device,
                                                            const vk::SwapchainKHR& swapchain,
                                                            const vk::Format image_format) {
-  return device.getSwapchainImagesKHR(swapchain) | std::ranges::views::transform([&device, image_format](auto&& image) {
+  return device.getSwapchainImagesKHR(swapchain) | std::views::transform([&device, image_format](auto&& image) {
            return device.createImageViewUnique(vk::ImageViewCreateInfo{
                .image = image,
                .viewType = vk::ImageViewType::e2D,

--- a/src/engine/window.cpp
+++ b/src/engine/window.cpp
@@ -44,7 +44,7 @@ using UniqueGlfwWindow = std::unique_ptr<GLFWwindow, decltype(&glfwDestroyWindow
 UniqueGlfwWindow CreateGlfwWindow(const char* const title, const int width, const int height) {
   [[maybe_unused]] const auto& glfw_context = GlfwContext::Get();
   auto* glfw_window = glfwCreateWindow(width, height, title, nullptr, nullptr);
-  if (glfw_window == nullptr) throw std::runtime_error{"Window creation failed"};
+  if (glfw_window == nullptr) throw std::runtime_error{"GLFW window creation failed"};
   return UniqueGlfwWindow{glfw_window, glfwDestroyWindow};
 }
 
@@ -80,8 +80,8 @@ std::span<const char* const> gfx::Window::GetInstanceExtensions() {
 
 vk::UniqueSurfaceKHR gfx::Window::CreateSurface(const vk::Instance& instance) const {
   VkSurfaceKHR surface{};
-  const auto result = glfwCreateWindowSurface(instance, glfw_window_.get(), nullptr, &surface);
-  vk::resultCheck(vk::Result{result}, "Window surface creation failed");
+  const auto result = static_cast<vk::Result>(glfwCreateWindowSurface(instance, glfw_window_.get(), nullptr, &surface));
+  vk::resultCheck(result, std::format("Window surface creation failed with error {}", vk::to_string(result)).c_str());
   const vk::ObjectDestroy<vk::Instance, VULKAN_HPP_DEFAULT_DISPATCHER_TYPE> deleter{instance};
   return vk::UniqueSurfaceKHR{vk::SurfaceKHR{surface}, deleter};
 }

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -15,8 +15,9 @@ gfx::Game::Game() noexcept : window_{"VkRender", kWindowHeight, kWindowWidth}, e
   });
 }
 
-void gfx::Game::Run() const {
+void gfx::Game::Run() {
   while (!window_.IsClosed()) {
     Window::Update();
+    engine_.Render();
   }
 }

--- a/src/game/include/game/game.h
+++ b/src/game/include/game/game.h
@@ -10,7 +10,7 @@ class Game {
 public:
   Game() noexcept;
 
-  void Run() const;
+  void Run();
 
 private:
   Window window_;

--- a/src/game/main.cpp
+++ b/src/game/main.cpp
@@ -6,7 +6,7 @@
 
 int main() {
   try {
-    const gfx::Game game{};
+    gfx::Game game{};
     game.Run();
   } catch (const std::exception& e) {
     std::cerr << e.what() << std::endl;


### PR DESCRIPTION
This commit enables rendering a single triangle by creating a graphics pipeline and allocating command buffers to record draw commands with explicit synchronization primitives.